### PR TITLE
switched from 'source' to 'ref' for model declarations

### DIFF
--- a/models/intermediate/covid/int_county_cases.sql
+++ b/models/intermediate/covid/int_county_cases.sql
@@ -1,6 +1,6 @@
 WITH stg_county_cases AS (
     
-    SELECT * FROM {{ source('dev_staging', 'stg_county_cases')}}
+    SELECT * FROM {{ ref('stg_county_cases')}}
 
 ), int_county_cases AS (
     SELECT

--- a/models/intermediate/ebird/int_ebird.sql
+++ b/models/intermediate/ebird/int_ebird.sql
@@ -1,5 +1,5 @@
 WITH stg_ebird AS (
-    SELECT * FROM {{ source('dev_staging', 'stg_ebird')}}
+    SELECT * FROM {{ ref('stg_ebird')}}
 )
 
 SELECT DISTINCT * FROM (

--- a/models/intermediate/google_calendar/int_google_calendar_dim.sql
+++ b/models/intermediate/google_calendar/int_google_calendar_dim.sql
@@ -1,5 +1,5 @@
 WITH stg_google_calendar AS (
-    SELECT * FROM {{ source( 'dev_staging', 'stg_google_calendar_dim') }}
+    SELECT * FROM {{ ref( 'stg_google_calendar_dim') }}
 ),
 
 stg_google_calendar_dates AS (

--- a/models/prod_dw/covid/county_cases.sql
+++ b/models/prod_dw/covid/county_cases.sql
@@ -1,5 +1,5 @@
 WITH int_county_cases AS (
-    SELECT * FROM {{ source('dev_intermediate', 'int_county_cases') }}
+    SELECT * FROM {{ ref( 'int_county_cases') }}
 )
 
 SELECT DISTINCT * FROM int_county_cases

--- a/models/prod_dw/ebird/ebird.sql
+++ b/models/prod_dw/ebird/ebird.sql
@@ -1,5 +1,5 @@
 WITH int_ebird AS (
-    SELECT * FROM {{ source('dev_intermediate', 'int_ebird')}}
+    SELECT * FROM {{ ref( 'int_ebird')}}
 )
 
 SELECT 

--- a/models/prod_dw/google_calendar/google_calendar_dim.sql
+++ b/models/prod_dw/google_calendar/google_calendar_dim.sql
@@ -1,5 +1,5 @@
 WITH int_google_calendar AS (
-    SELECT * FROM {{ source('dev_intermediate', 'int_google_calendar_dim')}}
+    SELECT * FROM {{ ref( 'int_google_calendar_dim')}}
 )
 
 SELECT * 


### PR DESCRIPTION
switching 'source' to 'ref' in order to show linear relationships throughout the lifecycle, versus only the previous source.