### PR TITLE
fixed scalar subquery results with aggregate

### DIFF
--- a/models/intermediate/ebird/int_ebird_obs.sql
+++ b/models/intermediate/ebird/int_ebird_obs.sql
@@ -40,7 +40,7 @@ SELECT DISTINCT * FROM (
 
         {% if is_incremental() %}
 
-        WHERE obs_dttm > (SELECT obs_dttm FROM {{ this }})
+        WHERE obs_dttm > (SELECT MAX(obs_dttm) FROM {{ this }})
 
         {% endif %}
         )


### PR DESCRIPTION
Updated `int_ebird_obs` incremental `WHERE` clause so it returned an aggergate, single result